### PR TITLE
Fix wiki links

### DIFF
--- a/ge.xml
+++ b/ge.xml
@@ -3415,7 +3415,7 @@
         <key key="payment:contactless" value="yes" />
         <reference ref="basic_data" />
         <reference ref="wheelchair_address" />
-        <link wiki="Tag:shop%3ticket" />
+        <link wiki="Tag:shop=ticket" />
       </item>
       <item name="Telmico" ka.name="თელმიკო" ru.name="Телмико" type="node,closedway,multipolygon" preset_name_label="true">
         <space />
@@ -3431,7 +3431,7 @@
         <key key="contact:phone" value="+995325000777" />
         <reference ref="basic_data" />
         <reference ref="wheelchair_address" />
-        <link wiki="Tag:office%3energy_supplier" />
+        <link wiki="Tag:office=energy_supplier" />
       </item>
     </group>
 


### PR DESCRIPTION
https://wiki.openstreetmap.org/wiki/Tag:office%3energy_supplier -> Tag:office>nergy_supplier (which is wrong). This fixes it by using `=` instead of the wrong url encoded version (it _could_ have been `%3D`, but `=` is more human readable).
https://wiki.openstreetmap.org/wiki/Tag:shop%3ticket -> 400 (the osm wiki server doesn't understand this request, also fixed by using `=`)

These issues were found by one of JOSM's integration jobs (see https://josm.openstreetmap.de/jenkins/job/JOSM-Integration/jdk=JDK8/9462/testReport/junit/org.openstreetmap.josm.gui.preferences.map/TaggingPresetPreferenceTestIT/Georgia___https___github_com_komachi_josm_ge_preset_blob_main_ge_xml/ )